### PR TITLE
Add freelancer registration UI and job-matching portal

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+import uuid
 from typing import Dict, List
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
 try:
@@ -73,11 +75,268 @@ resume_metadata: Dict[str, Dict] = {}
 
 @app.get("/")
 def healthcheck() -> Dict[str, str]:
-    return {"status": "ok", "service": "Freelancing AI Matching API"}
+    return {"status": "ok", "service": "Freelancing AI Matching API", "ui": "/ui"}
 
 
-@app.post("/upload-resume")
-async def upload_resume(file: UploadFile = File(...)) -> Dict:
+@app.get("/ui", response_class=HTMLResponse)
+def freelancer_portal() -> str:
+    return """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Freelancing AI Portal</title>
+      <style>
+        :root {
+          color-scheme: dark;
+          --bg: #0f172a;
+          --surface: #1e293b;
+          --surface-soft: #334155;
+          --text: #f8fafc;
+          --accent: #22d3ee;
+          --success: #22c55e;
+          --warning: #f59e0b;
+        }
+        body {
+          font-family: Inter, system-ui, -apple-system, sans-serif;
+          margin: 0;
+          background: linear-gradient(160deg, var(--bg), #020617);
+          color: var(--text);
+          min-height: 100vh;
+        }
+        .container {
+          max-width: 1024px;
+          margin: 0 auto;
+          padding: 2rem 1rem 4rem;
+        }
+        h1 { font-size: 2rem; margin-bottom: 0.25rem; }
+        .subtitle { color: #cbd5e1; margin-bottom: 1.5rem; }
+        .grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+          gap: 1rem;
+        }
+        .card {
+          background: rgba(30, 41, 59, 0.9);
+          border-radius: 14px;
+          padding: 1rem;
+          border: 1px solid rgba(148, 163, 184, 0.3);
+          box-shadow: 0 12px 28px rgba(2, 6, 23, 0.35);
+        }
+        label {
+          display: block;
+          font-size: 0.9rem;
+          margin-bottom: 0.25rem;
+          color: #cbd5e1;
+        }
+        input, textarea {
+          width: 100%;
+          border-radius: 8px;
+          border: 1px solid #475569;
+          background: var(--surface-soft);
+          color: var(--text);
+          padding: 0.65rem;
+          margin-bottom: 0.8rem;
+          box-sizing: border-box;
+        }
+        button {
+          width: 100%;
+          background: linear-gradient(110deg, #0891b2, var(--accent));
+          color: #082f49;
+          border: none;
+          border-radius: 10px;
+          font-weight: 700;
+          padding: 0.65rem;
+          cursor: pointer;
+        }
+        button:hover { filter: brightness(1.08); }
+        .message {
+          font-size: 0.9rem;
+          min-height: 1.1rem;
+          margin-top: 0.45rem;
+        }
+        .success { color: var(--success); }
+        .warning { color: var(--warning); }
+        table {
+          width: 100%;
+          border-collapse: collapse;
+          margin-top: 0.9rem;
+          font-size: 0.9rem;
+        }
+        th, td {
+          border-bottom: 1px solid #334155;
+          text-align: left;
+          padding: 0.45rem;
+        }
+        th { color: #67e8f9; }
+      </style>
+    </head>
+    <body>
+      <main class="container">
+        <h1>Freelancing AI Talent Portal</h1>
+        <p class="subtitle">Freelancers can upload resumes + profile details, and clients can instantly match job requirements.</p>
+
+        <section class="grid">
+          <article class="card">
+            <h2>Freelancer Registration</h2>
+            <form id="freelancerForm">
+              <label for="name">Full name</label>
+              <input id="name" name="name" required />
+
+              <label for="email">Email</label>
+              <input id="email" name="email" type="email" required />
+
+              <label for="headline">Role / Headline</label>
+              <input id="headline" name="headline" placeholder="Backend Python Developer" required />
+
+              <label for="experience">Experience years</label>
+              <input id="experience" name="experience_years" type="number" min="0" value="0" required />
+
+              <label for="skills">Skills (comma-separated)</label>
+              <input id="skills" name="skills" placeholder="python, fastapi, docker" />
+
+              <label for="bio">Short bio</label>
+              <textarea id="bio" name="bio" rows="3"></textarea>
+
+              <label for="resume">Resume (.txt)</label>
+              <input id="resume" name="resume" type="file" accept=".txt" required />
+
+              <button type="submit">Upload Resume & Register</button>
+              <p id="registerMessage" class="message"></p>
+            </form>
+          </article>
+
+          <article class="card">
+            <h2>Client Job Matching</h2>
+            <form id="jobForm">
+              <label for="description">Job description</label>
+              <textarea id="description" name="description" rows="4" minlength="10" required></textarea>
+
+              <label for="requiredSkills">Required skills (comma-separated)</label>
+              <input id="requiredSkills" name="requiredSkills" placeholder="react, node, aws" />
+
+              <label for="minExperience">Minimum experience years</label>
+              <input id="minExperience" name="minExperience" type="number" min="0" value="0" />
+
+              <button type="submit">Find Best Freelancers</button>
+              <p id="jobMessage" class="message"></p>
+            </form>
+            <div id="results"></div>
+          </article>
+        </section>
+      </main>
+
+      <script>
+        const registerMessage = document.getElementById('registerMessage');
+        const jobMessage = document.getElementById('jobMessage');
+        const resultsContainer = document.getElementById('results');
+
+        document.getElementById('freelancerForm').addEventListener('submit', async (event) => {
+          event.preventDefault();
+          registerMessage.className = 'message';
+          registerMessage.textContent = 'Uploading...';
+
+          const formElement = event.target;
+          const formData = new FormData();
+          formData.append('name', formElement.name.value);
+          formData.append('email', formElement.email.value);
+          formData.append('headline', formElement.headline.value);
+          formData.append('experience_years', formElement.experience_years.value);
+          formData.append('skills', formElement.skills.value);
+          formData.append('bio', formElement.bio.value);
+          formData.append('file', formElement.resume.files[0]);
+
+          try {
+            const response = await fetch('/freelancers/register', { method: 'POST', body: formData });
+            const data = await response.json();
+            if (!response.ok) {
+              throw new Error(data.detail || 'Failed to upload resume.');
+            }
+            registerMessage.className = 'message success';
+            registerMessage.textContent = `Registered ${data.profile.name} (ID: ${data.resume_id})`;
+            formElement.reset();
+          } catch (error) {
+            registerMessage.className = 'message warning';
+            registerMessage.textContent = error.message;
+          }
+        });
+
+        document.getElementById('jobForm').addEventListener('submit', async (event) => {
+          event.preventDefault();
+          jobMessage.className = 'message';
+          jobMessage.textContent = 'Matching candidates...';
+          resultsContainer.innerHTML = '';
+
+          const form = event.target;
+          const payload = {
+            description: form.description.value,
+            required_skills: form.requiredSkills.value
+              .split(',')
+              .map((skill) => skill.trim())
+              .filter(Boolean),
+            min_experience_years: Number(form.minExperience.value) || 0,
+          };
+
+          try {
+            const response = await fetch('/post-job', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            const data = await response.json();
+            if (!response.ok) {
+              throw new Error(data.detail || 'Job matching failed.');
+            }
+
+            jobMessage.className = 'message success';
+            jobMessage.textContent = `Found ${data.top_matches.length} top matches.`;
+
+            const rows = data.top_matches.map((match) => `
+              <tr>
+                <td>${match.name}</td>
+                <td>${match.headline}</td>
+                <td>${match.final_score}</td>
+                <td>${match.skill_score}</td>
+                <td>${match.experience_score}</td>
+              </tr>
+            `).join('');
+
+            resultsContainer.innerHTML = `
+              <table>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Headline</th>
+                    <th>Final Score</th>
+                    <th>Skill</th>
+                    <th>Experience</th>
+                  </tr>
+                </thead>
+                <tbody>${rows || '<tr><td colspan="5">No results.</td></tr>'}</tbody>
+              </table>
+            `;
+          } catch (error) {
+            jobMessage.className = 'message warning';
+            jobMessage.textContent = error.message;
+          }
+        });
+      </script>
+    </body>
+    </html>
+    """
+
+
+@app.post("/freelancers/register")
+async def register_freelancer(
+    name: str = Form(...),
+    email: str = Form(...),
+    headline: str = Form(...),
+    experience_years: int = Form(0),
+    skills: str = Form(""),
+    bio: str = Form(""),
+    file: UploadFile = File(...),
+) -> Dict:
     content = await file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Uploaded resume is empty.")
@@ -86,16 +345,56 @@ async def upload_resume(file: UploadFile = File(...)) -> Dict:
     if not text:
         raise HTTPException(status_code=400, detail="Could not parse UTF-8 text from resume.")
 
+    resume_id = f"resume-{uuid.uuid4().hex[:8]}"
     embedding = embedder.encode([text])[0]
-    resume_collection.add(documents=[text], embeddings=[embedding], ids=[file.filename])
+    resume_collection.add(documents=[text], embeddings=[embedding], ids=[resume_id])
+
+    typed_skills = [skill.strip().lower() for skill in skills.split(",") if skill.strip()]
+    inferred_skills = _extract_skills(text.lower())
+    merged_skills = sorted(set(typed_skills) | set(inferred_skills))
+
+    resume_metadata[resume_id] = {
+        "name": name,
+        "email": email,
+        "headline": headline,
+        "bio": bio,
+        "experience_years": max(experience_years, _extract_experience_years(text.lower())),
+        "skills": merged_skills,
+    }
+
+    return {
+        "message": "Freelancer registered successfully",
+        "resume_id": resume_id,
+        "profile": {"name": name, "email": email, "headline": headline, "skills": merged_skills},
+    }
+
+
+@app.post("/upload-resume")
+async def upload_resume(file: UploadFile = File(...)) -> Dict:
+    """Backward-compatible endpoint for plain resume-only uploads."""
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Uploaded resume is empty.")
+
+    text = content.decode("utf-8", errors="ignore").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Could not parse UTF-8 text from resume.")
+
+    resume_id = f"resume-{uuid.uuid4().hex[:8]}"
+    embedding = embedder.encode([text])[0]
+    resume_collection.add(documents=[text], embeddings=[embedding], ids=[resume_id])
 
     lowered = text.lower()
-    resume_metadata[file.filename] = {
+    resume_metadata[resume_id] = {
+        "name": file.filename,
+        "email": "",
+        "headline": "Freelancer",
+        "bio": "",
         "experience_years": _extract_experience_years(lowered),
         "skills": _extract_skills(lowered),
     }
 
-    return {"message": "Resume stored successfully", "resume_id": file.filename}
+    return {"message": "Resume stored successfully", "resume_id": resume_id}
 
 
 @app.post("/post-job")
@@ -119,6 +418,8 @@ def post_job(job: JobPost) -> Dict:
         ranked.append(
             {
                 "resume_id": result["id"],
+                "name": candidate.get("name", result["id"]),
+                "headline": candidate.get("headline", "Freelancer"),
                 "semantic_score": result["score"],
                 "skill_score": round(skill_score, 4),
                 "experience_score": round(experience_score, 4),


### PR DESCRIPTION
### Motivation
- Provide a simple browser UI and endpoints so freelancers can upload resumes and profile details and clients can run semantic job matching from the browser.
- Enable richer candidate metadata (name/headline/skills/experience) to be returned alongside matching scores so the frontend can render useful results.

### Description
- Added a new UI route at `GET /ui` that serves a single-page HTML portal with freelancer registration (profile + resume upload) and client job matching forms (main.py lines ~81-327). 
- Added `POST /freelancers/register` to accept multipart form data (`name`, `email`, `headline`, `experience_years`, `skills`, `bio`, `file`) and store a generated `resume_id` with merged typed + inferred skills (main.py lines ~330-369). 
- Kept `POST /upload-resume` for backward compatibility but changed storage to generated `resume_id` values and default profile metadata (main.py lines ~372-398). 
- Enhanced `POST /post-job` to include display metadata (`name`, `headline`) in match results while preserving semantic/skill/experience scoring so the UI can show candidate rows (main.py lines ~400-431). 

### Testing
- Ran `python -m compileall main.py` which compiled without syntax errors. 
- Attempted FastAPI TestClient smoke tests (UI page load, register flow, post-job flow) but they failed in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'fastapi'`).
- Generated a visual preview of the new `/ui` page via an automated Playwright script which produced a screenshot artifact for manual review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699885fa4954833389847114a47b228a)