### PR TITLE
Consolidate setup/run/test into single cross-platform script

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,3 +416,22 @@ Are you:
 * 🔵 Advanced (want scalable architecture design)
 
 Tell me your level, and I’ll build the next step exactly for you.
+
+---
+
+## Quick setup, run, and test
+
+### macOS / Linux / Windows (single script)
+
+```bash
+python scripts/setup.py
+```
+
+(or `python3 scripts/setup.py` on macOS/Linux)
+
+This single script uses OS `if` branches internally to:
+1. Create `.venv`
+2. Install dependencies
+3. Start the FastAPI app on `http://127.0.0.1:8000`
+4. Run automated API tests (`scripts/test_api.py`)
+5. Stop the server

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+VENV_DIR = ROOT_DIR / ".venv"
+IS_WINDOWS = os.name == "nt"
+PYTHON_BIN = os.environ.get("PYTHON_BIN", "python" if IS_WINDOWS else "python3")
+
+
+def run(cmd: list[str], check: bool = True) -> int:
+    print("+", " ".join(cmd))
+    result = subprocess.run(cmd, cwd=ROOT_DIR)
+    if check and result.returncode != 0:
+        raise SystemExit(result.returncode)
+    return result.returncode
+
+
+def wait_for_health(url: str, retries: int = 30, delay_s: int = 1) -> bool:
+    for _ in range(retries):
+        try:
+            with urlopen(url, timeout=2) as response:
+                if response.status == 200:
+                    return True
+        except URLError:
+            time.sleep(delay_s)
+    return False
+
+
+def find_missing_packages() -> list[str]:
+    required = ["fastapi", "uvicorn", "multipart", "requests"]
+    return [pkg for pkg in required if importlib.util.find_spec(pkg) is None]
+
+
+def main() -> None:
+    run([PYTHON_BIN, "--version"])
+    run([PYTHON_BIN, "-m", "venv", str(VENV_DIR), "--system-site-packages"])
+
+    venv_python = VENV_DIR / ("Scripts/python.exe" if IS_WINDOWS else "bin/python")
+
+    run([str(venv_python), "-m", "pip", "install", "--upgrade", "pip"], check=False)
+    run([str(venv_python), "-m", "pip", "install", "fastapi", "uvicorn", "python-multipart", "requests"], check=False)
+    run([str(venv_python), "-m", "pip", "install", "sentence-transformers"], check=False)
+
+    missing = find_missing_packages()
+    if missing:
+        raise SystemExit(f"Missing required packages: {missing}. Install them manually in this environment.")
+
+    log_file = Path(tempfile.gettempdir()) / "freelancing_ai_uvicorn.log"
+    with log_file.open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            [str(venv_python), "-m", "uvicorn", "main:app", "--host", "127.0.0.1", "--port", "8000"],
+            cwd=ROOT_DIR,
+            stdout=log,
+            stderr=log,
+        )
+
+    try:
+        if not wait_for_health("http://127.0.0.1:8000/"):
+            raise SystemExit(f"Server failed to start. Check log: {log_file}")
+
+        run([str(venv_python), "scripts/test_api.py"])
+
+        print("\nSetup + run + API test completed successfully.")
+        if IS_WINDOWS:
+            print("To run manually later:")
+            print("  .venv\\Scripts\\Activate.ps1")
+            print("  uvicorn main:app --reload --port 8000")
+        else:
+            print("To run manually later:")
+            print("  source .venv/bin/activate")
+            print("  uvicorn main:app --reload --port 8000")
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_api.py
+++ b/scripts/test_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import requests
+
+BASE = "http://127.0.0.1:8000"
+
+
+def assert_status(response: requests.Response, expected: int, message: str) -> None:
+    if response.status_code != expected:
+        raise RuntimeError(
+            f"{message}\nExpected HTTP {expected}, got {response.status_code}.\nBody: {response.text}"
+        )
+
+
+def main() -> None:
+    health = requests.get(f"{BASE}/", timeout=10)
+    assert_status(health, 200, "Health endpoint failed")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        resume_path = Path(tmp) / "resume.txt"
+        resume_path.write_text(
+            "Jane Developer\n"
+            "Backend Python engineer with 5 years experience.\n"
+            "Skills: Python, FastAPI, Docker, AWS, PostgreSQL.\n",
+            encoding="utf-8",
+        )
+
+        with resume_path.open("rb") as fh:
+            register = requests.post(
+                f"{BASE}/freelancers/register",
+                data={
+                    "name": "Jane Developer",
+                    "email": "jane@example.com",
+                    "headline": "Backend Python Developer",
+                    "experience_years": "5",
+                    "skills": "python,fastapi,docker,aws,postgresql",
+                    "bio": "Builds robust APIs",
+                },
+                files={"file": ("resume.txt", fh, "text/plain")},
+                timeout=20,
+            )
+        assert_status(register, 200, "Freelancer registration failed")
+
+    payload = {
+        "description": "Need a Python FastAPI developer to build backend APIs on AWS.",
+        "required_skills": ["python", "fastapi", "aws"],
+        "min_experience_years": 3,
+    }
+    match = requests.post(f"{BASE}/post-job", json=payload, timeout=20)
+    assert_status(match, 200, "Job matching failed")
+
+    data = match.json()
+    if "top_matches" not in data or not isinstance(data["top_matches"], list):
+        raise RuntimeError(f"Unexpected /post-job response: {json.dumps(data)}")
+    if not data["top_matches"]:
+        raise RuntimeError("No top matches returned after registration")
+
+    print("API tests passed: healthcheck, register, and post-job matching.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Replace duplicated platform-specific bootstrap scripts with a single cross-platform entrypoint to simplify onboarding and maintenance. 
- Make the setup/run/test flow identical across macOS, Linux, and Windows while handling OS-specific differences internally. 
- Provide a single documented command to create a venv, install deps, start the API, run a smoke test, and tear down the server.

### Description
- Add `scripts/setup.py`, a cross-platform Python script that creates `.venv`, attempts to install dependencies, starts the app with `uvicorn`, waits for a healthcheck, runs the smoke test, and stops the server; OS differences are handled via an `IS_WINDOWS` conditional. 
- Add `scripts/test_api.py`, an automated smoke test that exercises the root health endpoint, freelancer registration (with a resume file upload), and the `/post-job` matching endpoint. 
- Remove the previous platform-specific scripts `scripts/setup_mac.sh` and `scripts/setup_windows.ps1`. 
- Update `README.md` to document the unified invocation `python scripts/setup.py` (or `python3 scripts/setup.py`) for all platforms.

### Testing
- Ran `python3 -m py_compile main.py scripts/setup.py scripts/test_api.py` successfully to validate syntax. 
- Executed `python3 scripts/setup.py` in this environment; the script created a venv and attempted installs but pip installs failed due to outbound proxy/network restrictions, and the script exited with a clear missing-package message as designed. 
- The script includes a health-check retry loop and log capture for `uvicorn`, and it cleanly aborts with actionable guidance when required packages are missing (observed behavior in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de5c13f1c8330a1043aa96d923395)